### PR TITLE
fix(list-to-tree): respect empty_children option

### DIFF
--- a/dist/list-to-tree.js
+++ b/dist/list-to-tree.js
@@ -51,7 +51,7 @@ module.exports = class LTT{
     const { key_child, empty_children } = this.options;
     return this.tree.toJson({
       key_children: key_child,
-      empty_children: false,
+      empty_children
     })[key_child];
   }
 


### PR DESCRIPTION
pass in empty_children option instead of always passing false

closes #15 